### PR TITLE
Add create-rule tool for new rule creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Actual Budget MCP Server allows you to interact with your personal financial
 - **`spending-by-category`** - Generate spending breakdowns categorized by type
 - **`monthly-summary`** - Get monthly income, expenses, and savings metrics
 - **`balance-history`** - View account balance changes over time
+- **`create-rule`** - Create a categorization rule based on payee
 
 ### Prompts
 - **`financial-insights`** - Generate insights and recommendations based on your financial data

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -115,3 +115,13 @@ export async function getTransactions(accountId: string, start: string, end: str
   await initActualApi();
   return api.getTransactions(accountId, start, end);
 }
+
+export async function createRule(rule: unknown) {
+  await initActualApi();
+  return api.createRule(rule as any);
+}
+
+export async function getRules() {
+  await initActualApi();
+  return api.getRules();
+}

--- a/src/tools/create-rule/index.ts
+++ b/src/tools/create-rule/index.ts
@@ -1,0 +1,41 @@
+import { success, errorFromCatch } from "../../utils/response.js";
+import { createRule as apiCreateRule } from "../../actual-api.js";
+import type { CreateRuleArgs } from "../../types.js";
+
+export const schema = {
+  name: "create-rule",
+  description: "Create a categorization rule to assign a category based on payee",
+  inputSchema: {
+    type: "object",
+    properties: {
+      payee: { type: "string", description: "Payee name to match" },
+      categoryId: {
+        type: "string",
+        description: "Category ID to assign when the rule matches",
+      },
+      stage: {
+        type: "string",
+        enum: ["pre", "default", "post"],
+        description: "Rule stage (pre, default, or post)",
+        default: "pre",
+      },
+    },
+    required: ["payee", "categoryId"],
+  },
+};
+
+export async function handler(args: CreateRuleArgs) {
+  try {
+    const { payee, categoryId, stage = "pre" } = args;
+    const rule = {
+      stage,
+      conditionsOp: "and",
+      conditions: [{ field: "payee", op: "is", value: payee }],
+      actions: [{ field: "category", op: "set", value: categoryId }],
+    };
+    const created = await apiCreateRule(rule as any);
+    return success(`Rule created with id ${created.id}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import {
   SpendingByCategoryArgs,
   MonthlySummaryArgs,
   BalanceHistoryArgs,
+  CreateRuleArgs,
 } from "../types.js";
 import {
   schema as getTransactionsSchema,
@@ -30,6 +31,10 @@ import {
   schema as balanceHistorySchema,
   handler as balanceHistoryHandler,
 } from "./balance-history/index.js";
+import {
+  schema as createRuleSchema,
+  handler as createRuleHandler,
+} from "./create-rule/index.js";
 import { error, errorFromCatch } from "../utils/response.js";
 
 export const setupTools = (server: Server) => {
@@ -67,6 +72,10 @@ export const setupTools = (server: Server) => {
           return balanceHistoryHandler(args as unknown as BalanceHistoryArgs);
         }
 
+        case "create-rule": {
+          return createRuleHandler(args as unknown as CreateRuleArgs);
+        }
+
         default:
           return error(`Unknown tool ${name}`);
       }
@@ -86,6 +95,7 @@ function toolsSchema() {
       spendingByCategorySchema,
       monthlySummarySchema,
       balanceHistorySchema,
+      createRuleSchema,
     ],
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,12 @@ export interface BalanceHistoryArgs {
   months?: number;
 }
 
+export interface CreateRuleArgs {
+  payee: string;
+  categoryId: string;
+  stage?: string;
+}
+
 // Type for prompt arguments
 export interface FinancialInsightsArgs {
   startDate?: string;


### PR DESCRIPTION
## Summary
- introduce `create-rule` tool to add categorization rules
- export new helper functions in `actual-api`
- wire up tool in server
- document the new tool

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6849cf11fffc8326bdcbc77dde7b51a1