### PR TITLE
Add test suite and CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector -e ACTUAL_SERVER_URL=$ACTUAL_SERVER_URL -e ACTUAL_PASSWORD=$ACTUAL_PASSWORD -e ACTUAL_BUDGET_SYNC_ID=$ACTUAL_BUDGET_SYNC_ID node build/index.js",
     "start": "tsx src/index.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npm run build && node --test build/__tests__"
   },
   "dependencies": {
     "@actual-app/api": "^25.5.0",

--- a/src/__tests__/response.test.ts
+++ b/src/__tests__/response.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { success, successWithContent, error, errorFromCatch } from '../utils/response.js';
+
+test('success returns expected structure', () => {
+  const result = success('ok');
+  assert.deepStrictEqual(result, {
+    isError: false,
+    content: [{ type: 'text', text: 'ok' }]
+  });
+});
+
+test('successWithContent returns provided content', () => {
+  const result = successWithContent([{ type: 'text', text: 'hi' }]);
+  assert.deepStrictEqual(result, {
+    isError: false,
+    content: [{ type: 'text', text: 'hi' }]
+  });
+});
+
+test('error returns expected structure', () => {
+  const result = error('fail');
+  assert.deepStrictEqual(result, {
+    isError: true,
+    content: [{ type: 'text', text: 'Error: fail' }]
+  });
+});
+
+test('errorFromCatch handles Error objects', () => {
+  const result = errorFromCatch(new Error('boom'));
+  assert.deepStrictEqual(result, {
+    isError: true,
+    content: [{ type: 'text', text: 'Error: boom' }]
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a basic Node test for response helpers
- enable tests with `npm test`
- run tests in GitHub Actions on push and pull requests

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6849d2c099588326a33d18722372ad47